### PR TITLE
Add README and endpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Planta Tagger
+
+This is a small Flask service that inspects PDF architectural plans and
+attempts to identify the type of each page (e.g. floor levels, cuts,
+situational plans). The service is intended to be deployed using
+[Render](https://render.com) as defined in `render.yaml`.
+
+## Running locally
+
+Install the requirements and run `main.py`:
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+The API will be available on port `5000` by default.
+
+## Endpoint: `/identificar_plantas`
+
+Send a `POST` request with the PDF file in the `pdf` form field. The
+endpoint returns a JSON array where each element describes a page and the
+detected type.
+
+Example using `curl`:
+
+```bash
+curl -X POST -F pdf=@example.pdf http://localhost:5000/identificar_plantas
+```
+
+A successful response looks like:
+
+```json
+[
+  {"pagina": 1, "tipo_detectado": "terreo"},
+  {"pagina": 2, "tipo_detectado": "cobertura"}
+]
+```

--- a/main.py
+++ b/main.py
@@ -19,6 +19,16 @@ TIPOS_CHAVE = {
 
 @app.route("/identificar_plantas", methods=["POST"])
 def identificar_plantas():
+    """Receives a PDF file via ``multipart/form-data`` and returns a JSON array
+    with the detected page types.
+
+    **Request**
+        - ``pdf``: file field containing the plan PDF.
+
+    **Response**
+        ``200``: ``[{'pagina': int, 'tipo_detectado': str}, ...]``
+        ``400``: ``{'erro': 'PDF não enviado'}`` when the ``pdf`` field is missing.
+    """
     if "pdf" not in request.files:
         return jsonify({"erro": "PDF não enviado"}), 400
 


### PR DESCRIPTION
## Summary
- document running the service and calling `/identificar_plantas`
- explain request/response format in a new docstring on `identificar_plantas`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6850defd95348324b425833120d70f24